### PR TITLE
Soften version constraints

### DIFF
--- a/cubicaltt.cabal
+++ b/cubicaltt.cabal
@@ -40,15 +40,16 @@ executable cubical
     CPP,
     MagicHash
   build-depends:
-    base >=4.8 && <4.9,containers >=0.5 && <0.6,
+    base >=4.6 && <5,
+    containers >=0.5 && <0.6,
     pretty >=1.1 && <1.2,
-    QuickCheck >=2.8 && <2.9,
+    QuickCheck >=2.6 && <2.10,
     mtl >=2.2 && <2.3,
-    time >=1.5 && <1.6,
+    time >=1.4 && <1.6,
     directory >=1.2 && <1.3,
     filepath >=1.4 && <1.5,
     haskeline >=0.7 && <0.8,
-    array >=0.5 && <0.6
+    array >=0.4 && <0.6
   -- hs-source-dirs:
   build-tools:         alex, happy, bnfc
   default-language:    Haskell2010


### PR DESCRIPTION
This allows one to build cubicaltt on ubuntu 14.04 LTS
