### PR TITLE
Emacs mode: completion, imenu, and friendlier Customize

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ on emacs' ```load-path```, or else load it in advance, either manually with
 (load-file "cubicaltt.el")
 ```
 
+When using `ctt-mode` in Emacs, the command `ctt-load` will launch the
+interactive toplevel in an Emacs buffer and load the current file. It
+is bound to `C-c C-l` by default. If `cubical` is not on Emacs's
+`exec-path`, then set the variable `ctt-command` to the command that
+runs it.
+
 References and notes
 --------------------
 

--- a/cubicaltt.el
+++ b/cubicaltt.el
@@ -39,12 +39,16 @@
 
 ;;;; Customization options
 
-(defgroup ctt nil "Options for ctt-mode for cubical type theory" :group 'languages)
+(defgroup ctt nil "Options for ctt-mode for cubical type theory"
+  :group 'languages
+  :prefix 'ctt-
+  :tag "Cubical type theory")
 
 (defcustom ctt-command "cubical"
   "The command to be run for cubical."
   :group 'ctt
   :type 'string
+  :tag "Command for cubical"
   :options '("cubical" "cabal exec cubical"))
 
 ;;;; Syntax

--- a/cubicaltt.el
+++ b/cubicaltt.el
@@ -199,6 +199,12 @@ suggestions for completion rather than too few.")
   (set (make-local-variable 'completion-at-point-functions)
        '(ctt-completion-at-point))
 
+  ;; Setup imenu, to allow tools such as imenu and Helm to jump
+  ;; directly to names in the current buffer.
+  (set (make-local-variable 'imenu-generic-expression)
+       '(("Definitions" "^\\(?1:[[:word:]']+\\) *[:(]" 1)
+         ("Datatypes" "^\\s-*data\\s-+\\(?1:[[:word:]']+\\)" 1)))
+
   ;; Clear memory
   (setq ctt-keywords-regexp nil)
   (setq ctt-operators-regexp nil)


### PR DESCRIPTION
In addition to containing everything from #45, this pull request does the following to the Emacs mode:
1. The mode now follows more standard Elisp conventions.
2. Headers have been added for the Emacs package system, which enables compatibility with MELPA
3. Completion support is added, supporting the language keyword as well as those names that are easily findable with a simple regexp.
4. Imenu support allows tools to provide an index of the definitions in the current buffer.
5. The customization group and option from #45 now display with friendlier names in Customize.

I built this on top of #45 to prevent merge conflicts.
