### PR TITLE
Emacs mode: ignore backslash character

### DIFF
--- a/cubicaltt.el
+++ b/cubicaltt.el
@@ -90,6 +90,7 @@
     (modify-syntax-entry ?\}  "){4nb" st)
     (modify-syntax-entry ?-  "_ 123" st)
     (modify-syntax-entry ?\n ">" st)
+    (modify-syntax-entry ?\\ "." st)
     st)
   "The syntax table for cubical, with Haskell-style comments.")
 


### PR DESCRIPTION
Emacs treats the '\\' as an escape character by default, which means it sees `\(foo : x) -> bar` as having unbalanced parentheses and therefore `forward-sexp` and related functions don't work.