### PR TITLE
better error message from checkPLam

### DIFF
--- a/TypeChecker.hs
+++ b/TypeChecker.hs
@@ -403,7 +403,8 @@ checkPLam v t = do
   vt <- infer t
   case vt of
     VPathP a a0 a1 -> do
-      unlessM (a === v) $ throwError "checkPLam"
+      unlessM (a === v) $ throwError (
+        "checkPLam\n" ++ show v ++ "\n/=\n" ++ show a)
       return (a0,a1)
     _ -> throwError $ show vt ++ " is not a path"
 


### PR DESCRIPTION
Improve error message from checkPLam. The following is an example program that triggers the error:

    module test where

    Path (A : U) (a0 a1 : A) : U = PathP (<i> A) a0 a1

    bad (A B : U) (x y : A) (q : Path A x y) : Path (Path A x y) q q =
      <i> comp (<_> Path A x y) q [(i=0) -> q]
