### PR TITLE
More parentheses when printing values

### DIFF
--- a/CTT.hs
+++ b/CTT.hs
@@ -484,10 +484,7 @@ showVal1 v = case v of
   VVar{}            -> showVal v
   VFst{}            -> showVal v
   VSnd{}            -> showVal v
-  Ter t@Sum{} rho   -> showTer t <+> showEnv False rho
-  Ter t@HSum{} rho  -> showTer t <+> showEnv False rho
-  Ter t@Split{} rho -> showTer t <+> showEnv False rho
-  Ter t rho         -> showTer1 t <+> showEnv True rho
+  Ter t rho | showEnv False rho == PP.empty -> showTer1 t
   _                 -> parens (showVal v)
 
 showVals :: [Val] -> Doc


### PR DESCRIPTION
Fixes a bug where not enough parentheses would be printed.
Previously if a function F is defined by split, `F (F x)` would be printed as `F F x`.
Now it's printed as `F (F x)` as it should.

This is an example program able to demonstrate the difference:

    module bug where

    data Unit = tt

    data bool =
      false
      | true

    F (C : Unit -> U) : Unit -> U = split
      tt -> Unit

    bug : (x : Unit) -> F (F (F (\(_ : Unit) -> U))) x = ?
