### PR TITLE
Vim syntax file

### DIFF
--- a/cubicaltt.el
+++ b/cubicaltt.el
@@ -63,7 +63,7 @@
   "Operations for cubical.")
 
 (defvar cubicaltt-special
-  '("undefined" "primitive")
+  '("undefined")
   "Special operators for cubical.")
 
 (defvar cubicaltt-keywords-regexp

--- a/cubicaltt.vim
+++ b/cubicaltt.vim
@@ -1,0 +1,29 @@
+" Vim syntax file
+" Language:     cubicaltt
+" Author:       Carlo Angiuli
+" Last Change:  2017 November 6
+"
+" For https://github.com/mortberg/cubicaltt
+"
+" Move this file to ~/.vim/syntax/ and add the following line to your .vimrc:
+"   au BufNewFile,BufRead *.ctt setf cubicaltt
+
+if exists("b:current_syntax")
+  finish
+endif
+
+syn keyword cttKeyword hdata data import mutual let in split with module where
+syn keyword cttKeyword opaque transparent[] transparent_all
+syn keyword cttOperator U PathP comp transport fill Glue glue unglue Id idC idJ
+syn match   cttOperator '[:=|*_<>\-@]\|->\|\\\|\\/\|/\\'
+syn keyword cttUndef undefined
+
+syn region cttComment start="--" end="$"
+syn region cttComment start="{-" end="-}"
+
+hi def link cttKeyword Structure
+hi def link cttOperator Identifier
+hi def link cttUndef Todo
+hi def link cttComment Comment
+
+let b:current_syntax = "cubicaltt"


### PR DESCRIPTION
Here's a rudimentary Vim syntax file for cubicaltt (just highlighting; no SLIME features).

I've also deleted the nonexistent `primitive` keyword from the Emacs mode.